### PR TITLE
artworks and exhibitions seed created

### DIFF
--- a/database-seed/artworks-seed.json
+++ b/database-seed/artworks-seed.json
@@ -1,0 +1,151 @@
+[{
+    "_id": {
+      "$oid": "6425ba0ac9d195369ec02461"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sea-gallery-saya-aye.jpg",
+    "artistName": "Saya Aye",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "67 x 107.5 x 4.5 cm ",
+    "artworkInformation": "This acquisition was made possible with donations to the Art Adoption & Acquisition Programme. The relaxed poses of the sitters here distinguish this painting from other royal portraits, which are usually more formal. It is set in the interior court palace, and features familiar elements of Burmese palace architecture such as ornate gilded windows and fluted columns inspired by Western architecture. Such portraits were displayed in the living quarters of the wealthy or sometimes at religious ceremonies. Saya Aye was one of the first artists in Myanmar to combine traditional and Western techniques. He studied under the court painter Saya Chone, who pioneered the genre of royal family portraits towards the end of the Konbaung dynasty (1752–1885), the last royal dynasty in Myanmar.",
+    "artworkLocation": "Gallery 2, UOB Southeast Asia Gallery.",
+    "artworkMedium": "Oil on zinc",
+    "artworkTitle": "Royal Family Portrait with Moustached Minister",
+    "artworkYear": 1918
+  },{
+    "_id": {
+      "$oid": "6425bfb3c9d195369ec02471"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sea-gallery-vann-nath.jpg",
+    "artistName": "Vann Nath",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "98 x 142 cm",
+    "artworkInformation": "This painting depicts a scene from Vann Nath’s one-year incarceration at S-21 prison during the Khmer Rouge regime. Vann’s life was only spared by the prison commander Duch so that he could be put to work producing artworks of Pol Pot for propaganda purposes. Vann is shown presenting a portrait and a bust to Duch while a guard scrutinises the scene through a window. Vann uses architectural elements, such as the grid-like window grilles and air vents, to connect the different figures here: Commandant Duch, the artist, the painted portrait, the sculpted bust, and the prison guard are all implicated in the production of propaganda.\n\nVann was one of the few inmates to survive S-21, and is renowned for his chronicles of Khmer Rouge atrocities. Vann includes himself as a subject here, moving the painting beyond mere documentation.",
+    "artworkLocation": "Gallery 13, UOB Southeast Asia Gallery",
+    "artworkMedium": "Acrylic on canvas",
+    "artworkTitle": "The Commandant, also known as Painting Pol Pot for Duch",
+    "artworkYear": 1996
+  },{
+    "_id": {
+      "$oid": "6425c0a3c9d195369ec02472"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sea-gallery-po-po.jpg",
+    "artistName": "Po Po",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "78 x 78.5 cm",
+    "artworkInformation": "Here, Po Po uses a pattern of pinned and protruding nails to explore rhythm, light, shade and tactility. This work embodies Po Po’s search to break through the confines of fine art at the time. His practice focused on “object-ness,” and directly challenged conventional representational painting.\n\nThis work is part a series of three monochrome paintings shown at Po Po’s first solo exhibition, Untitled, held at the Myanmar Artistic Association Center in Yangon in 1987. This landmark show featured controversial pieces that radically departed from more traditional paintings. During this time, Po Po was an active participant in the artist collective Gangaw Village Art Group. Gangaw’s annual exhibitions were important sites for creative exchange in 1980s Myanmar, which was still closed to the world at the time due to policies implemented by its military government.",
+    "artworkLocation": "Gallery 12, UOB Southeast Asia Gallery",
+    "artworkMedium": "Oil on canvas",
+    "artworkTitle": "Painting for the Blind #3",
+    "artworkYear": 1986
+  },{
+    "_id": {
+      "$oid": "6425c122c9d195369ec02473"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sea-gallery-fx-harsono.jpg",
+    "artistName": "F.X. Harsono",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "",
+    "artworkInformation": "F.X. Harsono provokes the viewer to consider the infiltration of violence into everyday life here with a simple question: What Would You Do If These Crackers Were Real Pistols? The installation, comprising a pile of pistol-shaped crackers, desk and notebook for audience’s responses, is among Indonesia’s earliest participatory artworks.\n\nHarsono was a key figure in Indonesia’s New Arts Movement, a group which emerged in 1975 and sought change through new art forms and contemporary practices. He created this work in 1977 as a political statement against Indonesia’s then-President Suharto’s authoritarian New Order regime. “I bought the pistol crackers and just poured them on a gallery floor. A lot of people then linked my work with militarism, the regime,” the artist once explained.",
+    "artworkLocation": "Gallery 11, UOB Southeast Asia Gallery",
+    "artworkMedium": "Crackers, wooden table, chair, book, pen and instructions",
+    "artworkTitle": "What Would You Do If These Crackers Were Real Pistols?",
+    "artworkYear": 1977
+  },{
+    "_id": {
+      "$oid": "6425c1b4c9d195369ec02474"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sea-gallery-rong-wong-savun.jpg",
+    "artistName": "Rong Wong-Savun",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "25.5 x 25.3 cm",
+    "artworkInformation": "This cluster of photographs shows children on a mountain of garbage in Din Daeng, a district in Bangkok. Barefoot and mostly oblivious to the camera, they appear engrossed in the views surrounding them. This dumpsite issimultaneously depicted as their home, playground and scavenging site. The artist’s deliberate use of stark tonal contrasts underscores this desolate reality: light and shadow emphasise the horizon across the images, demarcating the expansive sky from the endless piles of garbage below.\n\nSites of urban squalor greatly increased in the 1950s and such images reveal a darker side of Bangkok. ’Rong Wong-Savun began exploring photography on his own as a teenager. At only 20 years old, five years before capturing these images, he was hired by Siam Rath Weekly Review, a newspaper founded by former Thai Prime Minister M. R. KukritPramoj.",
+    "artworkLocation": "Gallery 6, UOB Southeast Asia Gallery",
+    "artworkMedium": "Gelatin silver prints on paper",
+    "artworkTitle": "Din Daeng Dump Site",
+    "artworkYear": 1957
+  },{
+    "_id": {
+      "$oid": "6425c6a6c9d195369ec0248e"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sg-gallery-singapore.jpg",
+    "artistName": "John Turnbull Thomson ",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "57.3 x 88 cm",
+    "artworkInformation": "This painting portrays Singapore’s bustling waterfront, one of the most popular subjects in 19th century depictions of Singapore. Landmarks such as the Governor’s residence on Government Hill (present-day Fort Canning Hill) and Saint Andrew’s Cathedral, identifiable by its Gothic spire can be seen in the background. The foreground shows everyday life on the busy harbour with clipper ships and sampans ferrying goods and passengers, highlighting the then-colony’s importance as a free port.\n\nJohn Turnbull Thomson was Government Surveyor and Engineer for Singapore from 1841 to 1853. \nSites of urban squalor greatly increased in the 1950s and such images reveal a darker side of Bangkok. ’Rong Wong-Savun began exploring photography on his own as a teenager. At only 20 years old, five years before capturing these images, he was hired by Siam Rath Weekly Review, a newspaper founded by former Thai Prime Minister M. R. KukritPramoj.",
+    "artworkLocation": "Gallery 5, UOB Southeast Asia Gallery",
+    "artworkMedium": "Oil on canvas",
+    "artworkTitle": "Din Daeng Dump Site",
+    "artworkYear": 1957
+  },{
+    "_id": {
+      "$oid": "6425c70fc9d195369ec0248f"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sg-gallery-returning-from-market.jpg",
+    "artistName": "Chen Wen Hsi",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "91.3 x 106.6 cm ",
+    "artworkInformation": "This striking composition captures a scene of multi-racial Singapore. Chen Wen Hsi uses bold lines and blocks of colour to depict a group of figures in traditional dress. Despite the simplified forms, Chen renders the diverse patterns, colours, and textures of the subjects’ clothing in detail.\n\nThis work demonstrates Chen’s propensity for experimenting with various techniques to develop a unique style. His painting style draws from Cubism, which emphasises condensing three-dimensional forms into a single plan, and Fauvism, which prioritises conveying feeling and visual harmony through non-naturalistic colour. Chen’s ease with combining different approaches arose from working in Southeast Asia and specifically Singapore, where artists felt encouraged to explore and advance new visual languages to express a regional artistic identity.",
+    "artworkLocation": "Gallery 5, UOB Southeast Asia Gallery",
+    "artworkMedium": "Oil on canvas",
+    "artworkTitle": "Din Daeng Dump Site",
+    "artworkYear": 1960
+  },{
+    "_id": {
+      "$oid": "6425c74ec9d195369ec02490"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sg-gallery-untitled.jpg",
+    "artistName": "Lim Kwong Ling",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "50.7 x 40.6 cm",
+    "artworkInformation": "Lim Kwong Ling’s photographs have depicted various views of the Singapore River, a popular subject for painters and photographers in the 1960s and 1970s. This aerial river view was taken from atop the 52-storey OCBC Centre when construction was near completion. Before the decade-long clean-up effort was  initiated in 1977, the Singapore River was heavily polluted, bustling with trade and filled with bumboats. Lim’s river views document the changes taking place in the city-state as it experienced rapid urbanisation and industrialisation. \n\nLim Kwong Ling only started learning photography in his thirties when he began taking adult classes taught by Lee Sow Lim and the Photographic Society of Singapore (PSS) in the early 1960s. By the early 1970s, Lim’s focus had shifted from pictorial to documentary photography, reflecting a more realist approach to image-making.",
+    "artworkLocation": "Gallery 5, UOB Southeast Asia Gallery",
+    "artworkMedium": "Gelatin silver print",
+    "artworkTitle": "Not Titled ",
+    "artworkYear": 1970
+  },{
+    "_id": {
+      "$oid": "6425c781c9d195369ec02491"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sg-gallery-elizabeth-walk.jpg",
+    "artistName": "Tan Choon Ghee",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "33 x 35.5 cm",
+    "artworkInformation": "Tan Choon Gee made more than ten thousand sketches from life during his career. His figurative works, such as Elizabeth Walk, Singapore, were a product of close observation and the swift notation of figures. \n\nThis practice of sketching formed the basis of Tan’s distinctive style. His works are distinguished by subtle washes of colour, confident linework and a deft control of negative space. Trained at the Nanyang Academy of Fine Arts and the Slade School of Fine Arts in London, Tan combines different schools of watercolour painting in his works. The result is a masterful balance of confident linework and skilfully applied washes of colour. ",
+    "artworkLocation": "Gallery 5, UOB Southeast Asia Gallery",
+    "artworkMedium": "Ink and colour on paper",
+    "artworkTitle": "Elizabeth Walk, Singapore ",
+    "artworkYear": 1963
+  },{
+    "_id": {
+      "$oid": "6425c7c0c9d195369ec02492"
+    },
+    "artworkUrl": "https://www.nationalgallery.sg/sites/default/files/sg-gallery-the-animal-in-you.jpg",
+    "artistName": "Mohammad Din Mohammad",
+    "artworkComments": [
+      ""
+    ],
+    "artworkDimension": "136 x 109 33.5 cm",
+    "artworkInformation": "This work consists of an old tree trunk, heads of Javanese rod puppets (wayang golek) and tiger skin. The puppet heads represent mankind, which is depicted here as going through life on the back of carnal desires and emotions such as power and anger. Mohammad din Mohammad’s assemblages often tread the line between sculpture and object, inviting us to consider more expansive definitions of each term.\n\nMohammad Din Mohammad was a member of both the Modern Art Society and Angkatan Pelukis Aneka Daya (APAD) in Singapore. His choice of materials, and the symbolism in his works, reflect his background and training in Islamic aesthetics and traditional healing. ",
+    "artworkLocation": "Gallery 5, UOB Southeast Asia Gallery",
+    "artworkMedium": "Wood, tiger skin and paint",
+    "artworkTitle": "The Animal in You ",
+    "artworkYear": 2003
+  }]

--- a/database-seed/exhibitions-seed.json
+++ b/database-seed/exhibitions-seed.json
@@ -1,0 +1,64 @@
+[{
+    "_id": {
+      "$oid": "6425c260c9d195369ec02476"
+    },
+    "artworks": [
+      {
+        "$oid": "6415326a1fdaed807a26dd2e"
+      },
+      {
+        "$oid": "6425ba0ac9d195369ec02461"
+      },
+      {
+        "$oid": "6425bfb3c9d195369ec02471"
+      },
+      {
+        "$oid": "6425c0a3c9d195369ec02472"
+      },
+      {
+        "$oid": "6425c122c9d195369ec02473"
+      },
+      {
+        "$oid": "6425c1b4c9d195369ec02474"
+      }
+    ],
+    "exhibitionComments": [
+      ""
+    ],
+    "exhibitionEndDate": "16-3-2023",
+    "exhibitionEntry": "General Admission",
+    "exhibitionInformation": "Starting in the mid-19th century, the exhibition navigates the art history of Southeast Asia as one that is characterised by a continuous encounter with the new as the region’s artists negotiated the meaning of art and sought to reinvent vernacular expressions and aesthetics.\n\nPresented in a largely chronological sequence and punctuated by key turning points in artistic sensibilities, the exhibition also identifies how art is inseparably linked to the region’s tumultuous social and political history.\n\nThe title of the exhibition, Between Declarations and Dreams, is credited to one of Indonesia’s most cherished poets, Chairil Anwar. In his poem of 1948, \"Krawang-Bekasi”, Chairil Anwar laments the massacre of villagers in West Java by the Dutch colonial forces, giving vent to the desire for national independence at the time. This line may also be said to encapsulate the experiences of many artists in the region, caught as they are between declarations and dreams, the personal and the political.\n\nThe curatorial narrative explores four main themes places in a broadly chronological sequence, each one critically examining the shared artistic impulse of the region for each period: Authority and Anxiety, Imagining Country and Self, Manifesting the Nation, and Re:Defining Art.",
+    "exhibitionStartDate": "12-4-2022",
+    "exhibitionTitle": "Between Declarations and Dreams",
+    "exhibitionTitleSub": "Art of Southeast Asia since the 19th Century"
+  },{
+    "_id": {
+      "$oid": "6425c854c9d195369ec02494"
+    },
+    "artworks": [
+      {
+        "$oid": "6425c7c0c9d195369ec02492"
+      },
+      {
+        "$oid": "6425c781c9d195369ec02491"
+      },
+      {
+        "$oid": "6425c74ec9d195369ec02490"
+      },
+      {
+        "$oid": "6425c70fc9d195369ec0248f"
+      },
+      {
+        "$oid": "6425c6a6c9d195369ec0248e"
+      }
+    ],
+    "exhibitionComments": [
+      ""
+    ],
+    "exhibitionEndDate": "16-5-2023",
+    "exhibitionEntry": "General Admission",
+    "exhibitionInformation": "The most endearing fact about Singapore is her location: set in a vast archipelago of island neighbours, she raises questions of scale and proportion whenever she is contemplated. Geographically, she appears dwarfed by the immensity of her surroundings, leading her sea-locked inhabitants to constantly look outwards to the world at large. Yet her position in the world belies her physical size.  \n\nThis exhibition examines how artists in Singapore have grappled with similar issues since the 19th century, when much of Southeast Asia was under European colonial rule. With diverse values and systems coming into close contact with the region’s existing beliefs and social structures, the 19th century represents a break with what came before. It also marks the beginning of the modern condition and the rise of modern art in Southeast Asia and Singapore.\n\nIn Malay, “Siapa Nama Kamu?” means “What is your name?” This question is taken from National Language Class, a painting that hung on the walls of City Hall in the 1960s, where the Ministry of Culture was located. It was painted in 1959, the year Singapore gained self-governance from the British, and came to resonate with that historical change.\n\nThe display of about 300 works drawn from the National Collection and other sources provides a way to understand the history of Singapore art. Each artwork taken individually provides insights into why and how an artist responded to his surroundings and circumstances. Taken as a whole, the wide range of artworks reflects the complexities involved in telling this story.  \n\nSiapa Nama Kamu? is then a question and an invitation—to consider how art can operate as a mirror to but also complicate our reality.",
+    "exhibitionStartDate": "12-8-2022",
+    "exhibitionTitle": "Siapa Nama Kamu?",
+    "exhibitionTitleSub": "Art in Singapore since 19th Century"
+  }]

--- a/testmajoredit.md
+++ b/testmajoredit.md
@@ -1,1 +1,0 @@
-test test


### PR DESCRIPTION
Created seed consisting of 2 exhibitions and 10 artworks. The exhibitions have their respective artworks already in referenced format of an array of artwork object Id's